### PR TITLE
 Implement an option to set the filename for output data

### DIFF
--- a/util_pkt_logger/src/util_pkt_logger.c
+++ b/util_pkt_logger/src/util_pkt_logger.c
@@ -60,7 +60,6 @@ time_t now_time;
 time_t log_start_time;
 FILE * log_file = NULL;
 char log_file_name[64];
-bool use_stdout = false;
 
 /* -------------------------------------------------------------------------- */
 /* --- PRIVATE FUNCTIONS DECLARATION ---------------------------------------- */
@@ -348,15 +347,8 @@ void open_log(void) {
     strftime(iso_date,ARRAY_SIZE(iso_date),"%Y%m%dT%H%M%SZ",gmtime(&now_time)); /* format yyyymmddThhmmssZ */
     log_start_time = now_time; /* keep track of when the log was started, for log rotation */
 
-    if (strcmp(log_file_name, "") == 0) {
-        sprintf(log_file_name, "pktlog_%s_%s.csv", lgwm_str, iso_date);
-    }
+    sprintf(log_file_name, "pktlog_%s_%s.csv", lgwm_str, iso_date);
     log_file = fopen(log_file_name, "a"); /* create log file, append if file already exist */
-
-    if (use_stdout) {
-        log_file = stdout;
-        strncpy(log_file_name, "STDOUT", 64);
-    }
     if (log_file == NULL) {
         MSG("ERROR: impossible to create log file %s\n", log_file_name);
         exit(EXIT_FAILURE);
@@ -409,9 +401,8 @@ int main(int argc, char **argv)
     char fetch_timestamp[30];
     struct tm * x;
 
-
     /* parse command line options */
-    while ((i = getopt (argc, argv, "o:hr:")) != -1) {
+    while ((i = getopt (argc, argv, "hr:")) != -1) {
         switch (i) {
             case 'h':
                 usage();
@@ -425,13 +416,7 @@ int main(int argc, char **argv)
                     return EXIT_FAILURE;
                 }
                 break;
-	    case 'o':
-		if (strcmp(optarg, "-") == 0) {
-		    use_stdout = true;
-		} else {
-		    strncpy(log_file_name, optarg, 64);
-		}
-		break;
+
             default:
                 MSG("ERROR: argument parsing use -h option for help\n");
                 usage();

--- a/util_pkt_logger/src/util_pkt_logger.c
+++ b/util_pkt_logger/src/util_pkt_logger.c
@@ -377,6 +377,7 @@ void usage(void) {
     printf("*** Library version information ***\n%s\n\n", lgw_version_info());
     printf( "Available options:\n");
     printf( " -h print this help\n");
+    printf( " -o <filename|-> log data to this file, use - for stdout\n");
     printf( " -r <int> rotate log file every N seconds (-1 disable log rotation)\n");
 }
 

--- a/util_pkt_logger/src/util_pkt_logger.c
+++ b/util_pkt_logger/src/util_pkt_logger.c
@@ -369,7 +369,6 @@ void usage(void) {
     printf("*** Library version information ***\n%s\n\n", lgw_version_info());
     printf( "Available options:\n");
     printf( " -h print this help\n");
-    printf( " -o <filename|-> log data to this file, use - for stdout\n");
     printf( " -r <int> rotate log file every N seconds (-1 disable log rotation)\n");
 }
 

--- a/util_pkt_logger/src/util_pkt_logger.c
+++ b/util_pkt_logger/src/util_pkt_logger.c
@@ -60,6 +60,7 @@ time_t now_time;
 time_t log_start_time;
 FILE * log_file = NULL;
 char log_file_name[64];
+bool use_stdout = false;
 
 /* -------------------------------------------------------------------------- */
 /* --- PRIVATE FUNCTIONS DECLARATION ---------------------------------------- */
@@ -347,8 +348,15 @@ void open_log(void) {
     strftime(iso_date,ARRAY_SIZE(iso_date),"%Y%m%dT%H%M%SZ",gmtime(&now_time)); /* format yyyymmddThhmmssZ */
     log_start_time = now_time; /* keep track of when the log was started, for log rotation */
 
-    sprintf(log_file_name, "pktlog_%s_%s.csv", lgwm_str, iso_date);
+    if (strcmp(log_file_name, "") == 0) {
+        sprintf(log_file_name, "pktlog_%s_%s.csv", lgwm_str, iso_date);
+    }
     log_file = fopen(log_file_name, "a"); /* create log file, append if file already exist */
+
+    if (use_stdout) {
+        log_file = stdout;
+        strncpy(log_file_name, "STDOUT", 64);
+    }
     if (log_file == NULL) {
         MSG("ERROR: impossible to create log file %s\n", log_file_name);
         exit(EXIT_FAILURE);
@@ -400,8 +408,9 @@ int main(int argc, char **argv)
     char fetch_timestamp[30];
     struct tm * x;
 
+
     /* parse command line options */
-    while ((i = getopt (argc, argv, "hr:")) != -1) {
+    while ((i = getopt (argc, argv, "o:hr:")) != -1) {
         switch (i) {
             case 'h':
                 usage();
@@ -415,7 +424,13 @@ int main(int argc, char **argv)
                     return EXIT_FAILURE;
                 }
                 break;
-
+	    case 'o':
+		if (strcmp(optarg, "-") == 0) {
+		    use_stdout = true;
+		} else {
+		    strncpy(log_file_name, optarg, 64);
+		}
+		break;
             default:
                 MSG("ERROR: argument parsing use -h option for help\n");
                 usage();

--- a/util_pkt_logger/src/util_pkt_logger.c
+++ b/util_pkt_logger/src/util_pkt_logger.c
@@ -377,7 +377,7 @@ void usage(void) {
     printf("*** Library version information ***\n%s\n\n", lgw_version_info());
     printf( "Available options:\n");
     printf( " -h print this help\n");
-    printf( " -o <filename|-> log data to this file, use - for stdout\n");
+    printf( " -o <filename|-> log data to this file, use - for stdout (implies -r -1)\n");
     printf( " -r <int> rotate log file every N seconds (-1 disable log rotation)\n");
 }
 
@@ -431,6 +431,7 @@ int main(int argc, char **argv)
 		} else {
 		    strncpy(log_file_name, optarg, 64);
 		}
+		log_rotate_interval = -1;
 		break;
             default:
                 MSG("ERROR: argument parsing use -h option for help\n");

--- a/util_pkt_logger/src/util_pkt_logger.c
+++ b/util_pkt_logger/src/util_pkt_logger.c
@@ -595,7 +595,7 @@ int main(int argc, char **argv)
 
         /* check time and rotate log file if necessary */
         ++time_check;
-        if (time_check >= 8) {
+        if (log_rotate_interval >= 0 && time_check >= 8) {
             time_check = 0;
             time(&now_time);
             if (difftime(now_time, log_start_time) > log_rotate_interval) {


### PR DESCRIPTION
Hi!

I just created a patch to allow logging packets to a different file than the default generated. My main use for this is actually to send it to stdout, since that enables users to use this as a part of a conventional UNIX pipeline, i.e. you can for example transform and forward the data in novel ways with standard UNIX tools.

I hope this can be merged.

Cheers,

Kjetil