### PR TITLE
Spectral scan should not reset the FPGA

### DIFF
--- a/util_spectral_scan/src/util_spectral_scan.c
+++ b/util_spectral_scan/src/util_spectral_scan.c
@@ -264,7 +264,7 @@ int main( int argc, char ** argv )
             printf("ERROR: Failed to disconnect from FPGA\n");
             return EXIT_FAILURE;
         }
-        x = lgw_connect(false, LGW_DEFAULT_NOTCH_FREQ); /* FPGA reset/configure */
+        x = lgw_connect(true, 0);
         if(x != 0) {
             printf("ERROR: Failed to connect to FPGA\n");
             return EXIT_FAILURE;


### PR DESCRIPTION
The spectral scan should not reset the FPGA and should not need to set the NOTCH FREQ as it has already be set in the packet forwarder setup.

Calling lgw_connect to reset the FPGA and reconfigure will change the register page in the Sx1301 causing a timersync issue in the packet forwarder. Downlinks cannot be scheduled after spectral scan has run because the timestamp from the get_trigcnt is no longer valid.

THe LGW_TIMESTAMP register is on page 2 but the Sx1301 was reset to page 0. The packet forwarder is not aware of the page change and cannot recover.