### PR TITLE
Allow #define configuration of SPI parameters

### DIFF
--- a/libloragw/src/loragw_spi.native.c
+++ b/libloragw/src/loragw_spi.native.c
@@ -53,8 +53,12 @@ Maintainer: Sylvain Miermont
 
 #define READ_ACCESS     0x00
 #define WRITE_ACCESS    0x80
+#ifndef SPI_SPEED
 #define SPI_SPEED       8000000
+#endif
+#ifndef SPI_DEV_PATH
 #define SPI_DEV_PATH    "/dev/spidev0.0"
+#endif
 //#define SPI_DEV_PATH    "/dev/spidev32766.0"
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Enclose preprocessor define of SPI_SPEED and SPI_DEV_PATH in #ifndef
so that these values can optionally be passed by compiler / makefile
defines at build time for a specific platform or architecture.

Signed-off-by: Scott Wagner <scott.wagner@promethean-design.com>