### PR TITLE
Allow #define configuration of SPI parameters

### DIFF
--- a/libloragw/Makefile
+++ b/libloragw/Makefile
@@ -10,7 +10,7 @@ CROSS_COMPILE ?=
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-CFLAGS := -O2 -Wall -Wextra -std=c99 -Iinc -I.
+override CFLAGS += -O2 -Wall -Wextra -std=c99 -Iinc -I.
 
 OBJDIR = obj
 INCLUDES = $(wildcard inc/*.h)

--- a/libloragw/src/loragw_spi.native.c
+++ b/libloragw/src/loragw_spi.native.c
@@ -53,8 +53,12 @@ Maintainer: Sylvain Miermont
 
 #define READ_ACCESS     0x00
 #define WRITE_ACCESS    0x80
+#ifndef SPI_SPEED
 #define SPI_SPEED       8000000
+#endif
+#ifndef SPI_DEV_PATH
 #define SPI_DEV_PATH    "/dev/spidev0.0"
+#endif
 //#define SPI_DEV_PATH    "/dev/spidev32766.0"
 
 /* -------------------------------------------------------------------------- */

--- a/util_lbt_test/Makefile
+++ b/util_lbt_test/Makefile
@@ -17,7 +17,7 @@ include $(LGW_PATH)/library.cfg
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-CFLAGS=-O2 -Wall -Wextra -std=c99 -Iinc -I.
+override CFLAGS += -O2 -Wall -Wextra -std=c99 -Iinc -I.
 
 OBJDIR = obj
 

--- a/util_pkt_logger/Makefile
+++ b/util_pkt_logger/Makefile
@@ -17,7 +17,7 @@ include $(LGW_PATH)/library.cfg
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-CFLAGS=-O2 -Wall -Wextra -std=c99 -Iinc -I.
+override CFLAGS += -O2 -Wall -Wextra -std=c99 -Iinc -I.
 
 OBJDIR = obj
 

--- a/util_spectral_scan/Makefile
+++ b/util_spectral_scan/Makefile
@@ -12,7 +12,7 @@ include $(LGW_PATH)/library.cfg
 
 CC = $(CROSS_COMPILE)gcc
 AR = $(CROSS_COMPILE)ar
-CFLAGS = -O2 -Wall -Wextra -std=c99 -I inc
+override CFLAGS += -O2 -Wall -Wextra -std=c99 -I inc
 
 OBJDIR = obj
 INCLUDES = $(wildcard inc/*.h)

--- a/util_spi_stress/Makefile
+++ b/util_spi_stress/Makefile
@@ -18,7 +18,7 @@ include $(LGW_PATH)/library.cfg
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-CFLAGS=-O2 -Wall -Wextra -std=c99 -Iinc -I.
+override CFLAGS += -O2 -Wall -Wextra -std=c99 -Iinc -I.
 
 OBJDIR = obj
 

--- a/util_tx_continuous/Makefile
+++ b/util_tx_continuous/Makefile
@@ -18,7 +18,7 @@ include $(LGW_PATH)/library.cfg
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-CFLAGS=-O2 -Wall -Wextra -std=c99 -Iinc -I.
+override CFLAGS += -O2 -Wall -Wextra -std=c99 -Iinc -I.
 
 OBJDIR = obj
 

--- a/util_tx_test/Makefile
+++ b/util_tx_test/Makefile
@@ -18,7 +18,7 @@ include $(LGW_PATH)/library.cfg
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-override CFLAGS += CFLAGS=-O2 -Wall -Wextra -std=c99 -Iinc -I.
+override CFLAGS += -O2 -Wall -Wextra -std=c99 -Iinc -I.
 
 OBJDIR = obj
 

--- a/util_tx_test/Makefile
+++ b/util_tx_test/Makefile
@@ -18,7 +18,7 @@ include $(LGW_PATH)/library.cfg
 CC := $(CROSS_COMPILE)gcc
 AR := $(CROSS_COMPILE)ar
 
-CFLAGS=-O2 -Wall -Wextra -std=c99 -Iinc -I.
+override CFLAGS += CFLAGS=-O2 -Wall -Wextra -std=c99 -Iinc -I.
 
 OBJDIR = obj
 


### PR DESCRIPTION
Enclose preprocessor define of SPI_SPEED and SPI_DEV_PATH in #ifndef
so that these values can optinally be passed by compiler / makefile
defines at build time for a specific platform or architecture.

Allow CFLAGS to be passed in to Makefile (e.g. to allow preprocessor
defines to be set)